### PR TITLE
Decidim Cronjobs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gem "bootsnap", "~> 1.3"
 gem "puma", ">= 5.0.0"
 gem "faker", "~> 2.14"
 gem "wicked_pdf", "~> 2.1"
+gem "clockwork"
 
 group :development, :test do
   gem "byebug", "~> 11.0", platform: :mri

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -124,6 +124,9 @@ GEM
     chef-utils (17.9.26)
       concurrent-ruby
     childprocess (3.0.0)
+    clockwork (3.0.0)
+      activesupport
+      tzinfo
     coercible (1.0.0)
       descendants_tracker (~> 0.0.1)
     coffee-rails (5.0.0)
@@ -793,6 +796,7 @@ PLATFORMS
 DEPENDENCIES
   bootsnap (~> 1.3)
   byebug (~> 11.0)
+  clockwork
   daemons
   decidim (= 0.25.2)
   decidim-dev (= 0.25.2)

--- a/config/clockwork.rb
+++ b/config/clockwork.rb
@@ -1,0 +1,29 @@
+require 'clockwork'
+require 'rake'
+require 'active_support/time'
+require File.expand_path('../application.rb', __FILE__)
+
+Rake::Task.clear
+DecidimMonterrey::Application.load_tasks
+
+module Clockwork
+  # See  https://docs.decidim.org/en/install/#scheduled_tasks
+  DECIDIM_TASKS = [
+    'decidim:delete_data_portability_files',
+    'decidim:metrics:all',
+    'decidim:open_data:export',
+    'decidim_meetings:clean_registration_forms',
+    # NOTE: Reminders task is currently unavaliable in our Decidim version and
+    #       it hasn't been relased in any officila version. To get it we'd
+    #       need to point to master-branch, but we can hold as is for now.
+    # 'decidim:reminders:all'
+  ]
+
+  every(1.day, 'midnight jobs', at: '**:00', tz: 'America/Mexico_City') do
+    DECIDIM_TASKS.each do |task|
+      puts "Starting: #{task}"
+      Rake::Task[task].invoke
+      puts "Finished: #{task}"
+    end
+  end
+end


### PR DESCRIPTION
Optamos por usar `clockwork` para los cronjobs de la aplicacion de decidim, por ser una alternativa simple y "battle-tested"

Con estos cambios las tareas programadas (scheduled) correran todos los dias a media noche

### Como iniciar proceso en el servidor:
```
bundle exec clockwork config/clockwork.rb
```

### Captura de pantalla con pruebas en ambiente local:
![image](https://user-images.githubusercontent.com/39539196/152565833-7c037f3a-69f9-426a-a8a3-f45ad8b6c935.png)
