### PR TITLE
Dev/vote button

### DIFF
--- a/app/helpers/proposal_helper.rb
+++ b/app/helpers/proposal_helper.rb
@@ -1,0 +1,48 @@
+module ProposalHelper
+  PROPOSALS_COMPONENT_SCOPE_MESSAGE_KEY = {
+    "DELEGACIONES" => "decidim.proposals.proposals.voting_rules.proposal_scope.delegation",
+    "SECTORES" => "decidim.proposals.proposals.voting_rules.proposal_scope.sector"
+  }
+
+  USER_SCOPE_METADATA_KEY = {
+    "DELEGACIONES" => "delegation_code",
+    "SECTORES" => "sector_code"
+  }
+
+  def user_can_vote_delegation_proposal?(user, proposal)
+    authorization = ::Decidim::Authorization.where
+      .not(granted_at: nil)
+      .find_by!(user: user, name: "ine")
+
+    !authorization.nil? && proposal.scope.code == authorization.metadata["delegation_code"]
+  end
+
+  def user_can_vote_sector_proposal?(user, proposal)
+    authorization = ::Decidim::Authorization.where
+      .not(granted_at: nil)
+      .find_by!(user: user, name: "ine")
+
+    !authorization.nil? && proposal.scope.code == authorization.metadata["sector_code"]
+  end
+
+  def get_proposals_component_scope_message_key(component_settings)
+    component_scope = Decidim::Scope.find component_settings.scope_id
+    PROPOSALS_COMPONENT_SCOPE_MESSAGE_KEY[component_scope.code]
+  end
+
+  def is_component_scope_delegation?(component)
+    Decidim::Scope.find(component.settings.scope_id).code == "DELEGACIONES"
+  end
+
+  def is_component_scope_sector?(component)
+    Decidim::Scope.find(component.settings.scope_id).code == "SECTORES"
+  end
+
+  def user_scope_name(user, component_settings)
+    authorization = ::Decidim::Authorization.where
+      .not(granted_at: nil)
+      .find_by!(user: user, name: "ine")
+    component_scope = Decidim::Scope.find component_settings.scope_id
+    Decidim::Scope.find_by(code: authorization.metadata[USER_SCOPE_METADATA_KEY[component_scope.code]]).name
+  end
+end

--- a/app/views/decidim/proposals/proposals/_vote_button.html.erb
+++ b/app/views/decidim/proposals/proposals/_vote_button.html.erb
@@ -1,0 +1,59 @@
+<% if proposal.rejected? || proposal.withdrawn? %>
+  <div></div>
+<% else %>
+  <% if component_settings.participatory_texts_enabled? && from_proposals_list %>
+    <%= render partial: "decidim/proposals/proposals/participatory_texts/proposal_vote_button", locals: { proposal: proposal, from_proposals_list: true } %>
+  <% else %>
+    <div id="proposal-<%= proposal.id %>-vote-button" class="button--vote-button">
+      <% if !current_user %>
+        <% if current_settings.votes_blocked? %>
+          <%= action_authorized_button_to :vote, t("decidim.proposals.proposals.vote_button.votes_blocked"), proposal_proposal_vote_path(proposal_id: proposal, from_proposals_list: from_proposals_list), resource: proposal, class: "button #{vote_button_classes(from_proposals_list)} disabled", disabled: true %>
+        <% else %>
+          <%= action_authorized_button_to :vote, proposal_proposal_vote_path(proposal_id: proposal, from_proposals_list: from_proposals_list), resource: proposal, class: "button #{vote_button_classes(from_proposals_list)}", data: { disable: true, "redirect-url": proposal_path(proposal) } do %>
+            <%= t("decidim.proposals.proposals.vote_button.vote") %>
+            <span class="show-for-sr"><%= decidim_html_escape(present(proposal).title) %></span>
+          <% end %>
+        <% end %>
+      <% else %>
+        <% if @voted_proposals ? @voted_proposals.include?(proposal.id) : proposal.voted_by?(current_user) %>
+          <%= action_authorized_button_to(
+            :vote,
+            proposal_proposal_vote_path(proposal_id: proposal, from_proposals_list: from_proposals_list),
+            resource: proposal,
+            method: :delete,
+            remote: true,
+            data: {
+              disable: true,
+              original: t("decidim.proposals.proposals.vote_button.already_voted"),
+              replace: t("decidim.proposals.proposals.vote_button.already_voted_hover"),
+              "redirect-url": proposal_path(proposal)
+            },
+            class: "button #{vote_button_classes(from_proposals_list)} active light",
+            id: "vote_button-#{proposal.id}"
+          ) do %>
+            <%= icon("check", class: "icon--small") %>
+            <%= t("decidim.proposals.proposals.vote_button.already_voted") %>
+            <span class="show-for-sr"><%= decidim_html_escape(present(proposal).title) %></span>
+          <% end %>
+        <% else %>
+          <% if proposal.maximum_votes_reached? && !proposal.can_accumulate_supports_beyond_threshold && current_component.participatory_space.can_participate?(current_user) %>
+            <%= content_tag :button, t("decidim.proposals.proposals.vote_button.maximum_votes_reached"), class: "button #{vote_button_classes(from_proposals_list)} disabled", disabled: true %>
+          <% else %>
+            <% if vote_limit_enabled? && remaining_votes_count_for(current_user) == 0 %>
+              <%= content_tag :button, t("decidim.proposals.proposals.vote_button.no_votes_remaining"), class: "button #{vote_button_classes(from_proposals_list)}", disabled: true %>
+            <% elsif current_settings.votes_blocked? || !current_component.participatory_space.can_participate?(current_user) %>
+              <%= content_tag :button, t("decidim.proposals.proposals.vote_button.votes_blocked"), class: "button #{vote_button_classes(from_proposals_list)} disabled", disabled: true %>
+            <% elsif !belongs_to_scope(current_user, proposal) %>
+              <%= content_tag :button, t("decidim.proposals.proposals.vote_button.out_of_scope"), class: "button #{vote_button_classes(from_proposals_list)} disabled", disabled: true %>
+            <% else %>
+              <%= action_authorized_button_to :vote, proposal_proposal_vote_path(proposal_id: proposal, from_proposals_list: from_proposals_list), resource: proposal, remote: true, data: { disable: true, "redirect-url": proposal_path(proposal) }, class: "button #{vote_button_classes(from_proposals_list)}" do %>
+                <%= t("decidim.proposals.proposals.vote_button.vote") %>
+                <span class="show-for-sr"><%= decidim_html_escape(present(proposal).title) %></span>
+              <% end %>
+            <% end %>
+          <% end %>
+        <% end %>
+      <% end %>
+    </div>
+  <% end %>
+<% end %>

--- a/app/views/decidim/proposals/proposals/_vote_button.html.erb
+++ b/app/views/decidim/proposals/proposals/_vote_button.html.erb
@@ -43,8 +43,12 @@
               <%= content_tag :button, t("decidim.proposals.proposals.vote_button.no_votes_remaining"), class: "button #{vote_button_classes(from_proposals_list)}", disabled: true %>
             <% elsif current_settings.votes_blocked? || !current_component.participatory_space.can_participate?(current_user) %>
               <%= content_tag :button, t("decidim.proposals.proposals.vote_button.votes_blocked"), class: "button #{vote_button_classes(from_proposals_list)} disabled", disabled: true %>
-            <% elsif !belongs_to_scope(current_user, proposal) %>
-              <%= content_tag :button, t("decidim.proposals.proposals.vote_button.out_of_scope"), class: "button #{vote_button_classes(from_proposals_list)} disabled", disabled: true %>
+
+            <% elsif is_component_scope_delegation?(current_component) && !user_can_vote_delegation_proposal?(current_user, proposal) %>
+              <%= content_tag :button, t("decidim.proposals.proposals.vote_button.out_of_scope.delegation"), class: "button #{vote_button_classes(from_proposals_list)} disabled", disabled: true %>
+            <% elsif is_component_scope_sector?(current_component) && !user_can_vote_sector_proposal?(current_user, proposal) %>
+              <%= content_tag :button, t("decidim.proposals.proposals.vote_button.out_of_scope.sector"), class: "button #{vote_button_classes(from_proposals_list)} disabled", disabled: true %>
+
             <% else %>
               <%= action_authorized_button_to :vote, proposal_proposal_vote_path(proposal_id: proposal, from_proposals_list: from_proposals_list), resource: proposal, remote: true, data: { disable: true, "redirect-url": proposal_path(proposal) }, class: "button #{vote_button_classes(from_proposals_list)}" do %>
                 <%= t("decidim.proposals.proposals.vote_button.vote") %>

--- a/app/views/decidim/proposals/proposals/_voting_rules.html.erb
+++ b/app/views/decidim/proposals/proposals/_voting_rules.html.erb
@@ -5,7 +5,6 @@
         <div class="columns medium-8 large-9">
           <h3 class="heading3"><%= t(".title") %></h3>
           <ul>
-              <li><%= t(get_proposal_type(component_settings)) %>.</li>
             <% if vote_limit_enabled? %>
               <li><%= t(".vote_limit.description", limit: component_settings.vote_limit) %></li>
             <% end %>
@@ -27,6 +26,9 @@
                   <%= t(".minimum_votes_per_user.supports_remaining", remaining_votes: minimum_votes_per_user - votes_given) %>
                 <% end %>
               </li>
+            <% end %>
+            <% if component_settings.scopes_enabled %>
+              <li><%= t(get_proposals_component_scope_message_key(component_settings), scope_name: user_scope_name(current_user, component_settings)[I18n.locale.to_s]) %></li>
             <% end %>
           </ul>
         </div>

--- a/app/views/decidim/proposals/proposals/_voting_rules.html.erb
+++ b/app/views/decidim/proposals/proposals/_voting_rules.html.erb
@@ -1,0 +1,47 @@
+<% if show_voting_rules? %>
+  <div class="row column voting-rules">
+    <div class="callout secondary">
+      <div class="row">
+        <div class="columns medium-8 large-9">
+          <h3 class="heading3"><%= t(".title") %></h3>
+          <ul>
+              <li><%= t(get_proposal_type(component_settings)) %>.</li>
+            <% if vote_limit_enabled? %>
+              <li><%= t(".vote_limit.description", limit: component_settings.vote_limit) %></li>
+            <% end %>
+            <% if proposal_limit_enabled? %>
+              <li><%= t(".proposal_limit.description", limit: proposal_limit) %></li>
+            <% end %>
+            <% if threshold_per_proposal_enabled? %>
+              <li><%= t(".threshold_per_proposal.description", limit: threshold_per_proposal) %></li>
+            <% end %>
+            <% if can_accumulate_supports_beyond_threshold? %>
+              <li><%= t(".can_accumulate_supports_beyond_threshold.description", limit: threshold_per_proposal) %></li>
+            <% end %>
+            <% if minimum_votes_per_user_enabled? %>
+              <li>
+                <%= t(".minimum_votes_per_user.description", votes: minimum_votes_per_user) %>
+                <% if votes_given >= minimum_votes_per_user %>
+                  <%= t(".minimum_votes_per_user.given_enough_votes") %>
+                <% else %>
+                  <%= t(".minimum_votes_per_user.supports_remaining", remaining_votes: minimum_votes_per_user - votes_given) %>
+                <% end %>
+              </li>
+            <% end %>
+          </ul>
+        </div>
+        <% if current_user_can_vote? %>
+          <div class="columns medium-4 large-3">
+            <div class="card card--nomargin text-center remaining-votes-counter">
+              <div class="card__content">
+                <span class="definition-data__title"><%= t(".vote_limit.left", limit: component_settings.vote_limit) %></span>
+                <%= render partial: "decidim/proposals/proposals/remaining_votes_count" %>
+                <span class="extra__suport-text"><%= t(".vote_limit.votes") %></span>
+              </div>
+            </div>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/app/views/decidim/proposals/proposals/index.html.erb
+++ b/app/views/decidim/proposals/proposals/index.html.erb
@@ -1,0 +1,73 @@
+<%= render partial: "decidim/shared/component_announcement" %>
+
+<% if component_settings.geocoding_enabled? %>
+  <%= dynamic_map_for proposals_data_for_map(@all_geocoded_proposals) do %>
+    <template id="marker-popup">
+      <div class="map-info__content">
+        <h3>${title}</h3>
+        <div id="bodyContent">
+          <p>{{html body}}</p>
+          <div class="map__date-address">
+            <div class="address card__extra">
+              <div class="address__icon">{{html icon}}</div>
+              <div class="address__details">
+                <span>${address}</span><br>
+              </div>
+            </div>
+          </div>
+          <div class="map-info__button">
+            <a href="${link}" class="button button--sc">
+              <%= t(".view_proposal") %>
+            </a>
+          </div>
+        </div>
+      </div>
+    </template>
+  <% end %>
+<% end %>
+<%= render partial: "voting_rules" %>
+<div class="row columns">
+  <div class="title-action">
+    <h3 id="proposals-count" class="title-action__title section-heading">
+      <%= render partial: "count" %>
+    </h3>
+    <% if current_settings.creation_enabled && current_component.participatory_space.can_participate?(current_user) %>
+      <%= action_authorized_link_to :create, new_proposal_path, class: "title-action__action button small", data: { "redirect_url" => new_proposal_path } do %>
+        <%= t(".new_proposal") %>
+        <%= icon "plus", role: "img", "aria-hidden": true %>
+      <% end %>
+    <% end %>
+
+    <% if component_settings.collaborative_drafts_enabled? %>
+      <%= link_to t(".collaborative_drafts_list"), collaborative_drafts_path, class: "title-action__action button small hollow ml-s" %>
+    <% end %>
+  </div>
+</div>
+<div class="row">
+  <div class="columns mediumlarge-4 large-3">
+    <%= render partial: "filters_small_view" %>
+    <div class="card card--secondary show-for-mediumlarge">
+      <%= render partial: "filters" %>
+    </div>
+  </div>
+  <div id="proposals" class="columns mediumlarge-8 large-9" aria-live="polite">
+    <%= render partial: "proposals" %>
+  </div>
+</div>
+<div class="row">
+  <div class="text-right">
+    <%= link_to t(".see_all_withdrawn"), proposals_path("filter[state][]" => "withdrawn") %>
+  </div>
+</div>
+
+<%# Fragmento sacado de app/views/decidim/proposals/proposals_votes/update_buttons_and_counters.js.erb %>
+<script>
+window.onload = function() {
+  <% @proposals.each do |proposal| %>
+    var $proposalVoteButton = $('#proposal-<%= proposal.id %>-vote-button');
+    if($proposalVoteButton[0]) {
+      morphdom($proposalVoteButton[0], '<%= j(render partial: "decidim/proposals/proposals/vote_button", locals: { proposal: proposal, from_proposals_list: true }).strip.html_safe %>');
+    }
+  <% end %>
+};
+</script>

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1,11 +1,12 @@
-
 es:
   decidim:
     proposals:
       proposals:
         voting_rules:
-            district_auth: 
-              sector: Solo puedes votar por propuestas que pertenecen a tu sector
-              delegation: Solo puedes votar por propuestas que pertenecen a tu delegación
-        vote_button: 
-          out_of_scope: Esta propuesta no pertenece a tu distrito
+          proposal_scope:
+            sector: Solo puedes votar por propuestas que pertenecen a tu sector (%{scope_name}).
+            delegation: Solo puedes votar por propuestas que pertenecen a tu delegación (%{scope_name}).
+        vote_button:
+          out_of_scope:
+            sector: No pertenece a tu sector
+            delegation: No pertenece a tu delegación

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1,0 +1,11 @@
+
+es:
+  decidim:
+    proposals:
+      proposals:
+        voting_rules:
+            district_auth: 
+              sector: Solo puedes votar por propuestas que pertenecen a tu sector
+              delegation: Solo puedes votar por propuestas que pertenecen a tu delegación
+        vote_button: 
+          out_of_scope: Esta propuesta no pertenece a tu distrito

--- a/lib/extensions/decidim.rb
+++ b/lib/extensions/decidim.rb
@@ -3,6 +3,7 @@ require "extensions/decidim/proposals/current_user_scope"
 require "extensions/decidim/proposals/create_proposal"
 require "extensions/decidim/proposals/publish_proposal"
 require "extensions/decidim/proposals/update_proposal"
+require "extensions/decidim/proposals/vote_proposal"
 
 module Extensions
   module Decidim

--- a/lib/extensions/decidim/proposals/current_user_scope.rb
+++ b/lib/extensions/decidim/proposals/current_user_scope.rb
@@ -2,7 +2,6 @@ module Extensions
   module Decidim
     module Proposals
       module CurrentUserScope
-
         PARTICIPATORY_PROCESS_TYPE = {
           "DELEGACIONES" => "delegation_code",
           "SECTORES" => "sector_code"

--- a/lib/extensions/decidim/proposals/current_user_scope.rb
+++ b/lib/extensions/decidim/proposals/current_user_scope.rb
@@ -2,6 +2,7 @@ module Extensions
   module Decidim
     module Proposals
       module CurrentUserScope
+
         PARTICIPATORY_PROCESS_TYPE = {
           "DELEGACIONES" => "delegation_code",
           "SECTORES" => "sector_code"
@@ -12,7 +13,6 @@ module Extensions
             .not(granted_at: nil)
             .find_by!(user: @current_user, name: "ine")
           scope_type = PARTICIPATORY_PROCESS_TYPE[proposal.component.scope.code]
-
           ::Decidim::Scope.find_by! code: authorization.metadata[scope_type]
         end
       end

--- a/lib/extensions/decidim/proposals/vote_proposal.rb
+++ b/lib/extensions/decidim/proposals/vote_proposal.rb
@@ -3,14 +3,13 @@
 module Extensions
   module Decidim
     module Proposals
-
       module VoteProposal
         include Extensions::Decidim::Proposals::CurrentUserScope
 
         def call
           return broadcast(:invalid) if @proposal.maximum_votes_reached? && !@proposal.can_accumulate_supports_beyond_threshold
 
-          return broadcast(:invalid) if !can_user_vote_in_proposal?
+          return broadcast(:invalid) unless can_user_vote_in_proposal?
 
           build_proposal_vote
           return broadcast(:invalid) unless vote.valid?
@@ -32,9 +31,7 @@ module Extensions
         def can_user_vote_in_proposal?
           @proposal.scope == current_user_scope(@proposal)
         end
-
       end
-
     end
   end
 end

--- a/lib/extensions/decidim/proposals/vote_proposal.rb
+++ b/lib/extensions/decidim/proposals/vote_proposal.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module Extensions
+  module Decidim
+    module Proposals
+
+      module VoteProposal
+        include Extensions::Decidim::Proposals::CurrentUserScope
+
+        def call
+          return broadcast(:invalid) if @proposal.maximum_votes_reached? && !@proposal.can_accumulate_supports_beyond_threshold
+
+          return broadcast(:invalid) if !can_user_vote_in_proposal?
+
+          build_proposal_vote
+          return broadcast(:invalid) unless vote.valid?
+
+          ActiveRecord::Base.transaction do
+            @proposal.with_lock do
+              vote.save!
+              update_temporary_votes
+            end
+          end
+
+          # Decidim::Gamification.increment_score(@current_user, :proposal_votes)
+
+          broadcast(:ok, vote)
+        end
+
+        private
+
+        def can_user_vote_in_proposal?
+          @proposal.scope == current_user_scope(@proposal)
+        end
+
+      end
+
+    end
+  end
+end
+
+Decidim::Proposals::VoteProposal.prepend Extensions::Decidim::Proposals::VoteProposal


### PR DESCRIPTION
Un usuario solo puede votar en su delegación o sector.
- En el controlador de votos no se permite votar si no pertenece a la delegación o sector.
- Solucionada la vista de propuestas que no se actualizaba el boton al entrar.
- El botón se actualiza para mostrar si esa propuesta pertenece a su delegación o sector.