### PR TITLE
Refactor: Seeds 🌱

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,7 @@ group :development, :test do
 end
 
 group :development do
+  gem "ruby-progressbar"
   gem "letter_opener_web", "~> 1.3"
   gem "listen", "~> 3.1"
   gem "spring", "~> 2.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -828,6 +828,7 @@ DEPENDENCIES
   puma (>= 5.0.0)
   ripper-tags
   rspec-rails
+  ruby-progressbar
   spring (~> 2.0)
   spring-watcher-listen (~> 2.0)
   standard

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -2,67 +2,10 @@
 
 require "csv"
 
-def sort_csv(csv_rows, sort_column)
-  rows = []
-  csv_rows.each do |row|
-    rows << row.to_h
-  end
-  rows.sort_by { |row| row[sort_column] }
-end
+require "./db/seeds/organization"
+require "./db/seeds/scopes"
+require "./db/seeds/neighborhoods"
 
-def create_scopes(organization, scope_type_name, scope_type_plural, scopes_csv_name)
-  scope_type = Decidim::ScopeType.new(
-    decidim_organization_id: organization.id,
-    name: {'es': scope_type_name},
-    plural: {'es': scope_type_plural}
-  )
-  scope_type.save!
-  puts "Creating Scope Type: #{scope_type.id} | #{scope_type.name} | #{scope_type.plural}"
-
-  scope_root = Decidim::Scope.new(
-    decidim_organization_id: organization.id,
-    scope_type_id: nil,
-    name: {'es': scope_type_plural},
-    code: scope_type_plural.upcase,
-    parent_id: nil
-  )
-  scope_root.save!
-  puts "Creating Scope: #{scope_root.id} | #{scope_root.name} | #{scope_root.code} | #{scope_root.parent_id} | #{scope_root.part_of}"
-
-  scopes_csv = File.read("./db/csv/#{scopes_csv_name}.csv")
-  scopes = CSV.parse(scopes_csv, headers: true)
-  scopes = sort_csv(scopes, "name")
-  scopes.each do |s|
-    hash = s.to_hash
-    parent_scope = Decidim::Scope.find_by(code: hash["parent_code"])
-    scope = Decidim::Scope.new(
-      decidim_organization_id: organization.id,
-      scope_type_id: scope_type.id,
-      name: {'es': hash["name"]},
-      code: hash["code"],
-      parent_id: scope_root.id
-    )
-    scope.save!
-    scope.update(part_of: [scope.id] + (!parent_scope ? [] : parent_scope.part_of))
-    puts "Creating Scope: #{scope.id} | #{scope.name} | #{scope.code} | #{scope.parent_id} | #{scope.part_of}"
-  end
-end
-
-Decidim::Scope.destroy_all
-Decidim::ScopeType.destroy_all
-organization = Decidim::Organization.first
-create_scopes(organization, "Delegación", "Delegaciones", "delegations")
-create_scopes(organization, "Sector", "Sectores", "sectors")
-
-# --------------------------------------------------------------------------------
-# Neighborhoods
-# --------------------------------------------------------------------------------
-Decidim::Ine::Neighbourhood.destroy_all
-neighbourhoods_csv = File.read("db/csv/neighbourhoods.csv")
-neighbourhoods = CSV.parse(neighbourhoods_csv, headers: true)
-neighbourhoods = sort_csv(neighbourhoods, "name")
-neighbourhoods.each do |neighbourhood|
-  n = Decidim::Ine::Neighbourhood.new(neighbourhood.to_hash)
-  n.save!
-  puts "Creating neighbourhood: #{n.name} | #{n.code} | #{n.sector_code} | #{n.delegation_code}"
-end
+organization = Seeds::Organization.call
+Seeds::Scopes.call(organization)
+Seeds::Neighborhoods.call

--- a/db/seeds/neighborhoods.rb
+++ b/db/seeds/neighborhoods.rb
@@ -1,0 +1,22 @@
+require "csv"
+require "./db/seeds/progressbar"
+
+module Seeds
+  module Neighborhoods
+    def self.call
+      neighbourhoods = CSV.read("db/csv/neighbourhoods.csv", headers: true)
+        .by_row!
+        .sort_by { |row| row["name"] }
+
+      progressbar = Seeds::Progressbar.create(
+        title: "Neighborhoods",
+        total: neighbourhoods.count
+      )
+
+      neighbourhoods.each do |neighbourhood|
+        Decidim::Ine::Neighbourhood.find_or_create_by!(neighbourhood.to_hash)
+        progressbar.increment
+      end
+    end
+  end
+end

--- a/db/seeds/organization.rb
+++ b/db/seeds/organization.rb
@@ -1,0 +1,37 @@
+module Seeds
+  module Organization
+    def self.call
+      Decidim::Organization.find_or_create_by!(name: "Decidim Monterrey") do |org|
+        org.update!(
+          reference_prefix: "Instituto",
+          time_zone: "Central Time (US & Canada)",
+          host: "localhost:3000",
+          description: {"es" => "Lorem Ipsum..."},
+          default_locale: Decidim.default_locale,
+          available_locales: Decidim.available_locales,
+          users_registration_mode: :enabled,
+          official_url: "localhost:3000",
+          highlighted_content_banner_enabled: false,
+          enable_omnipresent_banner: false,
+          badges_enabled: false,
+          user_groups_enabled: true,
+          send_welcome_notification: true,
+          comments_max_length: 1000,
+          admin_terms_of_use_body: {"es" => "Admin terms of use"},
+          force_users_to_authenticate_before_access_organization: false,
+          machine_translation_display_priority: "original",
+          external_domain_whitelist: ["twitter.com", "facebook.com", "youtube.com", "github.com"],
+          smtp_settings: {
+            "from" => "test@example.org",
+            "user_name" => "test",
+            "encrypted_password" => Decidim::AttributeEncryptor.encrypt("demo"),
+            "port" => "25",
+            "address" => "smtp.example.org"
+          },
+          file_upload_settings: Decidim::OrganizationSettings.default(:upload),
+          enable_participatory_space_filters: true
+        )
+      end
+    end
+  end
+end

--- a/db/seeds/progressbar.rb
+++ b/db/seeds/progressbar.rb
@@ -1,0 +1,13 @@
+module Seeds
+  module Progressbar
+    def self.create(title:, total:)
+      ProgressBar.create(
+        title: title,
+        total: total,
+        format: "%a %b\u{15E7}%i %p%% %t",
+        progress_mark: " ",
+        remainder_mark: "\u{FF65}"
+      )
+    end
+  end
+end

--- a/db/seeds/scopes.rb
+++ b/db/seeds/scopes.rb
@@ -1,0 +1,57 @@
+require "csv"
+require "./db/seeds/progressbar"
+
+module Seeds
+  module Scopes
+    SCOPE_TYPES = {
+      "delegations" => {name: "Delegación", plural_name: "Delegaciones"},
+      "sectors" => {name: "Sector", plural_name: "Sectores"}
+    }.freeze
+
+    def self.call(organization)
+      @organization = organization
+
+      create_scopes_for("delegations")
+      create_scopes_for("sectors")
+    end
+
+    def self.create_scopes_for(type)
+      scope_type = Decidim::ScopeType.find_or_create_by!(
+        decidim_organization_id: @organization.id,
+        name: {'es': SCOPE_TYPES[type][:name]},
+        plural: {'es': SCOPE_TYPES[type][:plural_name]}
+      )
+
+      root_scope = Decidim::Scope.find_or_create_by!(
+        decidim_organization_id: @organization.id,
+        scope_type_id: nil,
+        name: {'es': SCOPE_TYPES[type][:plural_name]},
+        code: SCOPE_TYPES[type][:plural_name].upcase,
+        parent_id: nil
+      )
+
+      scopes = CSV.read("./db/csv/#{type}.csv", headers: true)
+        .by_row!
+        .sort_by { |row| row["name"] }
+
+      progressbar = Seeds::Progressbar.create(title: type, total: scopes.count)
+
+      scopes.each do |scope|
+        parent_scope = Decidim::Scope.find_by(code: scope["parent_code"])
+        scope = Decidim::Scope.new(
+          decidim_organization_id: @organization.id,
+          scope_type: scope_type,
+          name: {'es': scope["name"]},
+          code: scope["code"],
+          parent_id: root_scope.id
+        )
+
+        # TODO: Refactor
+        scope.update(part_of: [scope.id] + (!parent_scope ? [] : parent_scope.part_of))
+
+        sleep 0.05
+        progressbar.increment
+      end
+    end
+  end
+end


### PR DESCRIPTION
La idea original era solo arreglar los seeds para poder correrlos desde
un setup completamente nuevo, y que asi sea facil poder empezar a
contribuir.

Termine haciendo un refactor de los seeds, para que el codigo sea un
poco mas modular y legible.

Ademas de eso, se agrego el seed de Organization, ya que muchos de los
siguientes registros dependen de la existencia de este.

(Tambien por ahi puse un detalle chulo, que muestra un progress bar muy
mona cuando se corren seeds a partir de los CSVs)

TODO: 
- Agregar usuarios de prueba, admin, system y authorization validator para usarlos luego en pruebas de integracion

Ahora, se puede crear (o resetear) la base de datos en ambiente de desarrollo, sin que los seeds fallen.

https://user-images.githubusercontent.com/39539196/156835156-73196340-ed1b-4a84-8b16-f9bf1ded863d.mov

