### PR TITLE
Limitar votos en presupuestos

### DIFF
--- a/app/budgets/workflows/monterrey.rb
+++ b/app/budgets/workflows/monterrey.rb
@@ -1,0 +1,48 @@
+module Budgets
+  module Workflows
+    # This Workflow allows users to vote in the correspondent budgets according
+    # to their scope
+    class Monterrey < ::Decidim::Budgets::Workflows::Base
+      PARTICIPATORY_PROCESS_TYPE = {
+        "DELEGACIONES" => "delegation_code",
+        "SECTORES" => "sector_code"
+      }
+
+      def highlighted?(_resource)
+        false
+      end
+
+      # Users can vote in any budget that is into their scope
+      def vote_allowed?(budget, consider_progress: true)
+        return false unless current_user_scope(budget) == budget.scope
+
+        if consider_progress
+          progress?(budget) || progress.none?
+        else
+          true
+        end
+      end
+
+      # Public: Returns a list of budgets where the user can discard their order to vote in another.
+      #
+      # Returns Array.
+      def discardable
+        progress + voted
+      end
+
+      private
+
+      def current_user_scope(budget)
+        scope_type = PARTICIPATORY_PROCESS_TYPE[budget.scope.parent.code]
+
+        ::Decidim::Scope.find_by! code: user_authorization.metadata[scope_type]
+      end
+
+      def user_authorization
+        ::Decidim::Authorization.where
+          .not(granted_at: nil)
+          .find_by!(user: user, name: "ine")
+      end
+    end
+  end
+end

--- a/config/initializers/budgets_workflow.rb
+++ b/config/initializers/budgets_workflow.rb
@@ -1,0 +1,2 @@
+require "./app/budgets/workflows/monterrey"
+Decidim::Budgets.workflows[:monterrey] = Budgets::Workflows::Monterrey

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1,5 +1,11 @@
 es:
   decidim:
+    components:
+      budgets:
+        settings:
+          global:
+            workflow_choices:
+              monterrey: "Voto limitado a alcance: Permite a las participantes a votar solo en los presupuestos de su delegacion o sector"
     proposals:
       proposals:
         preview:


### PR DESCRIPTION
Fixes: #52 

Las usuarias solo pueden votar en presupuestos de su delegación o sector

Para esto tomamos total ventaja de los "Budgets Workflows", y creamos un
nuevo workflow, que de momento se llama "Monterrey"

Ver: https://docs.decidim.org/en/admin/components/budgets/#_workflows

Para poder probar manualmente esta funcionalidad, es importante seguir
las siguientes instrucciones:

- Al momento de crear el componente "Presupuestos" desde el panel de
  administracion, seleccionar la opcion que diga:
  "Voto limitado a alcance"
- Asignar un scope (ya sea delegacion o sector) a las proyectos creados

Las usuarios solo deberan tener acceso al voto en aquellos
presupuestos/proyectos que esten dentro de su scope (o sea, que el sector
o delegacion coincidan con los referenciados en su authorization)

#### Captura de pantalla
<img width="1792" alt="Screen Shot 2022-03-05 at 20 05 41" src="https://user-images.githubusercontent.com/39539196/156906101-6b1050ee-8f17-4462-9267-eccf9c36942b.png">
