### PR TITLE
Campo de CURP agregado a los formularios de verificación

### DIFF
--- a/decidim-module-ine/app/forms/decidim/ine/information_form.rb
+++ b/decidim-module-ine/app/forms/decidim/ine/information_form.rb
@@ -25,7 +25,7 @@ module Decidim
       validates :neighbourhood_code,
         inclusion: {in: :neighbourhoods_codes},
         presence: true
-      
+
       validates :curp,
         format: {with: /\A([A-Z][AEIOUX][A-Z]{2}\d{2}(?:0[1-9]|1[0-2])(?:0[1-9]|[12]\d|3[01])[HM](?:AS|B[CS]|C[CLMSH]|D[FG]|G[TR]|HG|JC|M[CNS]|N[ETL]|OC|PL|Q[TR]|S[PLR]|T[CSL]|VZ|YN|ZS)[B-DF-HJ-NP-TV-Z]{3}[A-Z\d])(\d)\z/, message: I18n.t("errors.messages.curp")},
         presence: true
@@ -65,7 +65,7 @@ module Decidim
 
       def unique_id
         # ToDo crear una cadena de texto única para cada usuario, por ejemplo con el nombre y email
-        "#{hash_curp(curp)}"
+        hash_curp(curp).to_s
       end
 
       def neighbourhoods_for_select

--- a/decidim-module-ine/app/forms/decidim/ine/information_form.rb
+++ b/decidim-module-ine/app/forms/decidim/ine/information_form.rb
@@ -9,6 +9,7 @@ module Decidim
       attribute :street_number, String
       attribute :postal_code, String
       attribute :neighbourhood_code, String
+      attribute :curp, String
 
       validates :street,
         presence: true
@@ -24,6 +25,10 @@ module Decidim
       validates :neighbourhood_code,
         inclusion: {in: :neighbourhoods_codes},
         presence: true
+      
+      validates :curp,
+        format: {with: /\A([A-Z][AEIOUX][A-Z]{2}\d{2}(?:0[1-9]|1[0-2])(?:0[1-9]|[12]\d|3[01])[HM](?:AS|B[CS]|C[CLMSH]|D[FG]|G[TR]|HG|JC|M[CNS]|N[ETL]|OC|PL|Q[TR]|S[PLR]|T[CSL]|VZ|YN|ZS)[B-DF-HJ-NP-TV-Z]{3}[A-Z\d])(\d)\z/, message: I18n.t("errors.messages.curp")},
+        presence: true
 
       def handler_name
         "ine"
@@ -34,6 +39,7 @@ module Decidim
         self.street_number = model.verification_metadata["street_number"]
         self.postal_code = model.verification_metadata["postal_code"]
         self.neighbourhood_code = model.verification_metadata["neighbourhood_code"]
+        self.curp = model.verification_metadata["curp"]
       end
 
       def verification_metadata
@@ -41,7 +47,8 @@ module Decidim
           "street" => street,
           "street_number" => street_number,
           "postal_code" => postal_code,
-          "neighbourhood_code" => neighbourhood_code
+          "neighbourhood_code" => neighbourhood_code,
+          "curp" => curp
         }
       end
 
@@ -58,7 +65,7 @@ module Decidim
 
       def unique_id
         # ToDo crear una cadena de texto única para cada usuario, por ejemplo con el nombre y email
-        "#{street}|#{street_number}|#{postal_code}|#{neighbourhood_code}"
+        "#{hash_curp(curp)}"
       end
 
       def neighbourhoods_for_select
@@ -80,6 +87,10 @@ module Decidim
 
       def neighbourhood_by_code(code)
         Decidim::Ine::Neighbourhood.find_by(code: code)
+      end
+
+      def hash_curp(curp)
+        Digest::MD5.hexdigest(curp)
       end
     end
   end

--- a/decidim-module-ine/app/views/decidim/ine/admin/confirmations/new.html.erb
+++ b/decidim-module-ine/app/views/decidim/ine/admin/confirmations/new.html.erb
@@ -47,6 +47,11 @@
           <%= t(".district") %>
           <input type="text" readonly="true" value='<%= @form.scope_by_code(@pending_authorization.metadata['district_code']).name['es'] %>'>
         </label>
+        <div class="row column">
+        <label>
+          <%= t(".curp") %>
+          <input type="text" readonly="true" value="<%= @pending_authorization.verification_metadata['curp'] %>">
+        </label>
       </div>
     </div>
   </div>

--- a/decidim-module-ine/app/views/decidim/ine/authorizations/_form.html.erb
+++ b/decidim-module-ine/app/views/decidim/ine/authorizations/_form.html.erb
@@ -30,6 +30,10 @@
   </div>
 
   <div class="field">
+    <%= form.text_field :curp, label: t(".curp") %>
+  </div>
+
+  <div class="field">
     <%= form.upload :verification_attachment, label: t(".verification_attachment") %>
   </div>
 

--- a/decidim-module-ine/config/locales/es.yml
+++ b/decidim-module-ine/config/locales/es.yml
@@ -89,4 +89,4 @@ es:
     messages:
       postal_code: Debe ser un código postal correcto
       number: Debe ser un número
-      curp: Cantidad inválida de caracteres para una CURP
+      curp: CURP incorrecto

--- a/decidim-module-ine/config/locales/es.yml
+++ b/decidim-module-ine/config/locales/es.yml
@@ -46,6 +46,7 @@ es:
             street_number: Número
             postal_code: Código Postal
             neighbourhood: Colonia
+            curp: CURP
             district: Distrito
             zone: Zona
             municipality: Municipio
@@ -71,6 +72,7 @@ es:
           street_number: Número (exterior)
           postal_code: Código Postal
           neighbourhood: Colonia (Como aparece en tu identificación o Carta de Residencia)
+          curp: CURP
           verification_attachment: Carga tu credencial para votar INE o Carta de Residencia
     authorization_handlers:
       admin:
@@ -87,3 +89,4 @@ es:
     messages:
       postal_code: Debe ser un código postal correcto
       number: Debe ser un número
+      curp: Cantidad inválida de caracteres para una CURP


### PR DESCRIPTION
Cambios en el modulo de verificaciones INE (decidim-ine-module). Se requeria agregar la CURP para generar _unique_id_ de los usuarios.

- Se agregó a los formularios, tanto de usuario como de admin, el campo CURP.
- Se genera hash de la CURP del usuario y se guarda como _unique_id_ usando MD5
  `Digest::MD5.hexdigest(curp)`

Formulario para solicitar verificación:
![image](https://user-images.githubusercontent.com/93446468/158478432-0838ddb1-36f0-4648-b5d7-de12579a9fa5.png)

Formulario para aceptar verificación (admin):
![image](https://user-images.githubusercontent.com/93446468/158479004-0bf46ca8-231f-4d90-b900-f0736fa75716.png)

