### PR TITLE
Teléfono no debería ser obligatorio en el registro. Cambios en el formato de su validación.

### DIFF
--- a/app/views/decidim/devise/registrations/new.html.erb
+++ b/app/views/decidim/devise/registrations/new.html.erb
@@ -49,7 +49,7 @@
             </div>
 
             <div class="field">
-              <%= f.phone_field :phone, type: :tel %>
+              <%= f.text_field :phone, help_text: t(".phone_help") %>
             </div>
 
             <div class="field">

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -2,7 +2,7 @@ es:
   activemodel:
     attributes:
       user:
-        phone: Número telefónico
+        phone: Número teléfono
   decidim:
     forms:
       current_file: Archivo actual
@@ -71,6 +71,7 @@ es:
     devise:
       registrations:
         new:
+          phone_help: (Campo opcional) Introducir un número de contacto
           subtitle: Crea una cuenta para poder participar subiendo y votando propuestas
   managed_user_authorization:
     form:
@@ -81,4 +82,5 @@ es:
       curp: CURP
   errors:
     messages:
+      phone_taken: Ya existe un usuario con ese número de teléfono
       curp: No es un CURP válido

--- a/lib/extensions/decidim/registrations/registrations_form.rb
+++ b/lib/extensions/decidim/registrations/registrations_form.rb
@@ -5,15 +5,15 @@ module Extensions
 
       included do
         attribute :phone, String
-        validates :phone, allow_nil: true, format: /[0-9]{10}/
-        validate :mobile_phone_number_unique_in_organization
+        validates :phone, allow_nil: true, allow_blank: true, format: /\A[\+]?[0-9]{10,13}\z/
+        validate :phone_unique_in_organization
 
-        def mobile_phone_number_unique_in_organization
-          existing_user = ::Decidim::User.no_active_invitation
+        def phone_unique_in_organization
+          return unless phone && phone.length >= 10
+          user_with_same_phone = ::Decidim::User.no_active_invitation
             .find_by(phone: phone, organization: current_organization)
-            .present?
 
-          errors.add :phone, :taken if existing_user.present?
+          errors.add :phone, :taken if user_with_same_phone.present?
         end
       end
     end

--- a/lib/extensions/decidim/registrations/registrations_form.rb
+++ b/lib/extensions/decidim/registrations/registrations_form.rb
@@ -5,7 +5,7 @@ module Extensions
 
       included do
         attribute :phone, String
-        validates :phone, allow_nil: true, allow_blank: true, format: /\A[\+]?[0-9]{10,13}\z/
+        validates :phone, allow_nil: true, allow_blank: true, format: /\A\+?[0-9]{10,13}\z/
         validate :phone_unique_in_organization
 
         def phone_unique_in_organization


### PR DESCRIPTION
El registro estaba fallando porque pedía obligatoriamente el número.