### PR TITLE
Fix: Filtrado de propuestas

### DIFF
--- a/app/views/decidim/proposals/proposals/index.js.erb
+++ b/app/views/decidim/proposals/proposals/index.js.erb
@@ -1,0 +1,10 @@
+var $proposals = $('#proposals');
+var $proposalsCount = $('#proposals-count');
+var $orderFilterInput = $('.order_filter');
+
+$proposals.html('<%= j(render partial: "proposals").strip.html_safe %>');
+$proposalsCount.html('<%= j(render partial: "count").strip.html_safe %>');
+$orderFilterInput.val('<%= order %>');
+
+var $dropdownMenu = $('.dropdown.menu', $proposals);
+$dropdownMenu.foundation();


### PR DESCRIPTION
> En el listado de propuestas, no se está filtrando correctamente.
> Aparecen propuestas que no deberían aparecer.

Este filtrado hace una llamada asincrona al momento de agregar o remover
un filtro, la cual esta regresando los resultados correctamente, pero
por alguna razon no estaba actualizando el contenido al vuelo. Para
hacer funcionar el filtro seleccionado se tenia que hacer un reload de
la pagina.

Basicamente, Rails estaba dandole prioridad a la vista que se habia
sobre-escrito en el proyecto de Decidim-Monterrey, ignorando
completamente la vista que provee la gema para peticiones asincronas o
tipo AJAX. La solucion fue simplemente sobre-escribir esta vista tipo
js.erb tambien, para que Rails pudiese tomar la vista apropiada
dependiendo del tipo de peticion

Fixes: #72 