### PR TITLE
Fixes admin's permission to upload images on Quill editor

### DIFF
--- a/.github/workflows/standardrb-rspec.yml
+++ b/.github/workflows/standardrb-rspec.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
-      - run: bin/standardrb --config ${{ github.workspace }}.standard.yml
+      - run: bin/standardrb --config ${{ github.workspace }}/.standard.yml
 
   rspec:
     runs-on: ubuntu-latest

--- a/.github/workflows/standardrb-rspec.yml
+++ b/.github/workflows/standardrb-rspec.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
-      - run: bin/standardrb
+      - run: bin/standardrb --config .standard.yml
 
   rspec:
     runs-on: ubuntu-latest

--- a/.github/workflows/standardrb-rspec.yml
+++ b/.github/workflows/standardrb-rspec.yml
@@ -15,7 +15,9 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
-      - run: bin/standardrb --config ${{ github.workspace }}/.standard.yml
+      - run: cat .standard.yml
+      - run: $PWD
+      - run: bin/standardrb --config .standard.yml
 
   rspec:
     runs-on: ubuntu-latest

--- a/.github/workflows/standardrb-rspec.yml
+++ b/.github/workflows/standardrb-rspec.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
-      - run: bin/standardrb --config ${{ github.workspace + '.standard.yml' }}
+      - run: bin/standardrb --config ${{ github.workspace }}.standard.yml
 
   rspec:
     runs-on: ubuntu-latest

--- a/.github/workflows/standardrb-rspec.yml
+++ b/.github/workflows/standardrb-rspec.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
-      - run: bin/standardrb --config ./.standard.yml
+      - run: bin/standardrb --config ${{ github.workspace + '.standard.yml' }}
 
   rspec:
     runs-on: ubuntu-latest

--- a/.github/workflows/standardrb-rspec.yml
+++ b/.github/workflows/standardrb-rspec.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
-      - run: bin/standardrb --config .standard.yml
+      - run: bin/standardrb --config /.standard.yml
 
   rspec:
     runs-on: ubuntu-latest

--- a/.github/workflows/standardrb-rspec.yml
+++ b/.github/workflows/standardrb-rspec.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
-      - run: bin/standardrb --config /.standard.yml
+      - run: bin/standardrb --config ./.standard.yml
 
   rspec:
     runs-on: ubuntu-latest

--- a/.github/workflows/standardrb-rspec.yml
+++ b/.github/workflows/standardrb-rspec.yml
@@ -15,8 +15,6 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
-      - run: cat .standard.yml
-      - run: $PWD
       - run: bin/standardrb --config .standard.yml
 
   rspec:

--- a/.standard.yml
+++ b/.standard.yml
@@ -1,0 +1,3 @@
+ignore:
+  - app/overrides/**/*:
+    - Lint/ConstantDefinitionInBlock

--- a/lib/extensions/decidim/admin/permissions.rb
+++ b/lib/extensions/decidim/admin/permissions.rb
@@ -5,8 +5,6 @@ module Extensions
         def permissions
 
           read_admin_dashboard_action?
-          allow! if permission_action.subject == :global_moderation
-          apply_newsletter_permissions_for_admin!
 
           if authorization_valuator?
             begin

--- a/lib/extensions/decidim/admin/permissions.rb
+++ b/lib/extensions/decidim/admin/permissions.rb
@@ -3,27 +3,6 @@ module Extensions
     module Admin
       module Permissions
         def permissions
-          return permission_action if managed_user_action?
-
-          unless permission_action.scope == :admin
-            read_admin_dashboard_action?
-            return permission_action
-          end
-
-          unless user
-            disallow!
-            return permission_action
-          end
-
-          if user_manager?
-            begin
-              allow! if user_manager_permissions.allowed?
-            rescue ::Decidim::PermissionAction::PermissionNotSetError
-              nil
-            end
-          end
-
-          allow! if user_can_enter_space_area?(require_admin_terms_accepted: true)
 
           read_admin_dashboard_action?
           allow! if permission_action.subject == :global_moderation
@@ -37,33 +16,7 @@ module Extensions
             end
           end
 
-          if user.admin? && admin_terms_accepted?
-            allow! if read_admin_log_action?
-            allow! if read_metrics_action?
-            allow! if static_page_action?
-            allow! if organization_action?
-            allow! if user_action?
-
-            allow! if permission_action.subject == :category
-            allow! if permission_action.subject == :component
-            allow! if permission_action.subject == :admin_user
-            allow! if permission_action.subject == :attachment
-            allow! if permission_action.subject == :attachment_collection
-            allow! if permission_action.subject == :scope
-            allow! if permission_action.subject == :scope_type
-            allow! if permission_action.subject == :area
-            allow! if permission_action.subject == :area_type
-            allow! if permission_action.subject == :user_group
-            allow! if permission_action.subject == :officialization
-            allow! if permission_action.subject == :moderate_users
-            allow! if permission_action.subject == :authorization
-            allow! if permission_action.subject == :authorization_workflow
-            allow! if permission_action.subject == :static_page_topic
-            allow! if permission_action.subject == :help_sections
-            allow! if permission_action.subject == :share_token
-          end
-
-          permission_action
+          super
         end
 
         private

--- a/lib/extensions/decidim/admin/permissions.rb
+++ b/lib/extensions/decidim/admin/permissions.rb
@@ -3,7 +3,6 @@ module Extensions
     module Admin
       module Permissions
         def permissions
-
           read_admin_dashboard_action?
 
           if authorization_valuator?


### PR DESCRIPTION
Related to issue #130 

This issue happened because the permissions function has changed since version 0.25.0, introducing a permission to [add images in quill editor](https://github.com/decidim/decidim/pull/8250) among other things.

To make the function resilient to future changes I used `super` and only left relevant parts of the modified function which require the authorization_valuator logic

Lines https://github.com/CodeandoMexico/decidim-monterrey/pull/131/files#diff-17fa1a84e8e079878f6e5df010b9844985c527b773233b4df6ede732a05026c4L29 were also removed as they are part of the original function